### PR TITLE
Altered a "bad" example that didn't actually work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -817,10 +817,7 @@ Other Style Guides
 
     ```javascript
     // bad
-    [1, 2, 3].map(number => {
-      const nextNumber = number + 1;
-      `A string containing the ${nextNumber}.`;
-    });
+    [1, 2, 3].map(number => { return `A string containing the ${number}.`; });
 
     // good
     [1, 2, 3].map(number => `A string containing the ${number}.`);


### PR DESCRIPTION
This previously gave the example:

```
[1, 2, 3].map(number => {
  const nextNumber = number + 1;
  `A string containing the ${nextNumber}.`;
});
```

However, in both node 5, and node 6, this example doesn't actually work. It certainly is "bad" but not for the given reason. It also gave me (and perhaps others) the impression that the final statement was implicitly returned when it's not.

```
$  docker run -it --rm node:6 node
> const test = [1, 2, 3].map(number => {
... const nextNumber = number + 1;
... `A string containing the ${nextNumber}.`;
... });
undefined
> test
[ undefined, undefined, undefined ]
>
(To exit, press ^C again or type .exit)
>

$  docker run -it --rm node:5 node
> const test = [1, 2, 3].map(number => {
... const nextNumber = number + 1;
... `A string containing the ${nextNumber}.`;
... });
undefined
> test
[ undefined, undefined, undefined ]
>
(To exit, press ^C again or type .exit)
>
```

I've chosen another example that does work and seems "bad" based on the explanation given in the guide.

```
& docker run -it --rm node:5 node
> let test = [1, 2, 3].map(number => { return `A string containing the ${number}.`; });
undefined
> test
[ 'A string containing the 1.',
  'A string containing the 2.',
  'A string containing the 3.' ]
>
(To exit, press ^C again or type .exit)
>});


$ docker run -it --rm node:6 node
> let test = [1, 2, 3].map(number => { return `A string containing the ${number}.`; });
undefined
> test
[ 'A string containing the 1.',
  'A string containing the 2.',
  'A string containing the 3.' ]
>
(To exit, press ^C again or type .exit)
>});
```
